### PR TITLE
Make hconsDecodeJson decode the tail lazily

### DIFF
--- a/src/main/scala/argonaut/AutoDecodeJsons.scala
+++ b/src/main/scala/argonaut/AutoDecodeJsons.scala
@@ -1,6 +1,6 @@
 package argonaut
 
-import scalaz.Scalaz._
+import scalaz.Scalaz.{^ => apply2, _}
 import shapeless._, labelled.{ FieldType, field }
 
 trait AutoDecodeJsons {
@@ -19,7 +19,9 @@ trait AutoDecodeJsons {
   ): DecodeJson[FieldType[K, H] :: T] =
     DecodeJson { c =>
       val headJson = c --\ key.value.name
-      (headJson.as(headDecode.value).map(field[K](_)) |@| headJson.delete.as(tailDecode.value))(_ :: _)
+      val head = headJson.as(headDecode.value).map(field[K](_))
+      lazy val tail = headJson.delete.as(tailDecode.value)
+      apply2(head, tail)(_ :: _)
     }
 
   implicit val cnilDecodeJson: DecodeJson[CNil] = 


### PR DESCRIPTION
Scalaz's `|@|` operator (from `ApplicativeBuilder`) has a feature/bug of being strict in both arguments. This means that the `DecodeJson` instance derived by `hconsDecodeJson` will continue decoding the tail of the `HList`, even if those results will eventually be discarded because of a failure in the head.

I performed some very quick and dirty microbenchmarking (using code in my branch [laziness-microbenchmarks] [1]). It indicated a slight performance gain (for both successful and failed decodes) simply from getting rid of `ApplicativeBuilder`, and significant gains for decodes that fail early on, from making `tail` lazy.

[1]: https://github.com/bmjames/argonaut-shapeless/tree/laziness-microbenchmark