### PR TITLE
Upgrade to shapeless 2.1.0 final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,12 +28,12 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= {
   if (scalaVersion.value startsWith "2.10.")
     Seq(
-      "com.chuusai" %% "shapeless" % "2.1.0-RC2" cross CrossVersion.full,
+      "com.chuusai" %% "shapeless" % "2.1.0" cross CrossVersion.full,
       compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
     )
   else
     Seq(
-      "com.chuusai" %% "shapeless" % "2.1.0-RC2"
+      "com.chuusai" %% "shapeless" % "2.1.0"
     )
 }
 


### PR DESCRIPTION
Trivial change. It would be good to have a new release to avoid SBT eviction warnings due to mismatched Shapeless release versions.