### PR TITLE
Update to refined 0.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val refinedCompileSettings = coreCompileSettings ++ Seq(
   libraryDependencies ++= {
     if (scalaVersion.value.startsWith("2.11."))
       Seq(
-        "eu.timepit" %% "refined" % "0.2.1" exclude("com.chuusai", "shapeless_" + scalaBinaryVersion.value)
+        "eu.timepit" %% "refined" % "0.2.2" exclude("com.chuusai", "shapeless_" + scalaBinaryVersion.value)
       )
     else
       Seq.empty

--- a/refined/src/main/scala/argonaut/RefinedInstances.scala
+++ b/refined/src/main/scala/argonaut/RefinedInstances.scala
@@ -1,7 +1,7 @@
 package argonaut
 
-import eu.timepit.refined._
-import eu.timepit.refined.internal.{ RefineAux, Wrapper }
+import eu.timepit.refined.Predicate
+import eu.timepit.refined.RefType
 import language.higherKinds
 
 trait RefinedInstances {
@@ -10,11 +10,11 @@ trait RefinedInstances {
    (implicit
      underlying: DecodeJson[T],
      predicate: Predicate[P, T],
-     wrapper: Wrapper[F]
+     refType: RefType[F]
    ): DecodeJson[F[T, P]] =
     DecodeJson { c =>
       underlying.decode(c).flatMap { t0 =>
-        new RefineAux[P, F].apply[T](t0) match {
+        refType.refine(t0) match {
           case Left(err) => DecodeResult.fail(err, c.history)
           case Right(t)  => DecodeResult.ok(t)
         }
@@ -24,10 +24,9 @@ trait RefinedInstances {
   implicit def refinedEncodeJson[T, P, F[_, _]]
    (implicit
      underlying: EncodeJson[T],
-     predicate: Predicate[P, T],
-     wrapper: Wrapper[F]
+     refType: RefType[F]
    ): EncodeJson[F[T, P]] =
-    underlying.contramap(wrapper.unwrap)
+    underlying.contramap(refType.unwrap)
 
 }
 


### PR DESCRIPTION
`internal.Wrapper` has been replaced by `RefType` which has a nicer API in this case (there is no need to use `RefineAux` helper class here). I've also removed the `Predicate` dependency from `refinedEncodeJson` since it is not used there.