### PR TITLE
Update to refined 0.3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val refinedSettings = Seq(
   libraryDependencies ++= Seq(
     "io.argonaut" %% "argonaut" % "6.1",
     "com.chuusai" %% "shapeless" % shapelessVersion,
-    "eu.timepit" %% "refined" % "0.3.3"
+    "eu.timepit" %% "refined" % "0.3.6"
   )
 )
 


### PR DESCRIPTION
This version of refined was built with shapeless 2.3.0.