### PR TITLE
Add JsonProductCodec to always include default case class values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,14 @@ CC(i = 4, s = "baz").asJson.nospaces == """{"s":"baz"}"""
 """{"s":"a"}""".decodeOption[CC] == Some(CC(s = "a"))
 ```
 
+This can be turned off by providing the alwaysIncludeDefaultValue `JsonProductCodecFor`. 
 
+```scala
+implicit def alwaysIncludeCodecFor[T]: derive.JsonProductCodecFor[T] =
+    derive.JsonProductCodecFor.alwaysIncludeDefaultValue
+
+CC().asJson.nospaces == """{"i":4,"s":"foo"}"""
+```
 
 
 ### Custom encoding of case classes

--- a/core/src/main/scala/argonaut/derive/JsonProductCodec.scala
+++ b/core/src/main/scala/argonaut/derive/JsonProductCodec.scala
@@ -14,6 +14,12 @@ object JsonProductCodec {
   def adapt(f: String => String): JsonProductCodec = new JsonProductObjCodec {
     override def toJsonName(name: String) = f(name)
   }
+
+  val alwaysIncludeDefaultValue: JsonProductCodec = new JsonProductObjCodec {
+    override def encodeField(field: (String, Json), obj: Json, default: => Option[Json]): Json = {
+      super.encodeField(field, obj, Option.empty[Json])
+    }
+  }
 }
 
 trait JsonProductCodecFor[P] {
@@ -28,6 +34,9 @@ object JsonProductCodecFor {
 
   implicit def default[T]: JsonProductCodecFor[T] =
     JsonProductCodecFor(JsonProductCodec.obj)
+
+  def alwaysIncludeDefaultValue[T]: JsonProductCodecFor[T] =
+    JsonProductCodecFor(JsonProductCodec.alwaysIncludeDefaultValue)
 }
 
 class JsonProductObjCodec extends JsonProductCodec {

--- a/test/src/test/scala/argonaut/DefaultTests.scala
+++ b/test/src/test/scala/argonaut/DefaultTests.scala
@@ -1,9 +1,9 @@
 package argonaut
 
 import utest._
-
 import argonaut.Argonaut._
 import argonaut.ArgonautShapeless._
+import argonaut.derive.{JsonProductCodec, JsonProductCodecFor}
 
 object DefaultTests extends TestSuite {
 
@@ -41,6 +41,22 @@ object DefaultTests extends TestSuite {
       val result1 = decoder.decodeJson(expectedJson1)
       val expectedResult1 = DecodeResult.ok(value1)
       assert(result1 == expectedResult1)
+    }
+
+    'alwaysIncludeDefaultValue - {
+      implicit def alwaysIncludeCodecFor[T]: JsonProductCodecFor[T] =
+        JsonProductCodecFor.alwaysIncludeDefaultValue
+
+      val encoder = EncodeJson.of[WithDefaults]
+
+      val value = WithDefaults(2)
+      val json = encoder.encode(value)
+      val expectedJson = Json.obj(
+        "i" -> Json.jNumber(2),
+        "s" -> Json.jString("b")
+      )
+
+      assert(json == expectedJson)
     }
   }
 


### PR DESCRIPTION
Provide an alternative to the behaviour of leaving fields out of Json when they have the same value as the case class default.

This makes use of the JsonProductCodec similar to https://github.com/alexarchambault/argonaut-shapeless#custom-encoding-of-case-classes.

Im very impressed by how flexible and powerful the API is, and how easy it was to add this.