### PR TITLE
Adopt the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+argonaut-shapeless is part of the shapeless ecosystem of
+[Typelevel](http://typelevel.org/), and as such endorses the
+[Scala Code of Conduct](https://typelevel.org/code-of-conduct.html).
+
+Concerns or issues can be sent to any of argonaut-shapeless'
+maintainers, or to the [Typelevel](http://typelevel.org/about.html)
+organization.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Automatic [argonaut](https://github.com/argonaut-io/argonaut) codec derivation w
 It is available for scala 2.10, 2.11, and 2.12, and depends on argonaut 6.2.
 
 argonaut-shapeless is part of the shapeless ecosystem of
-[Typelevel](http://typelevel.org/), and as such endorses its
-[Code of Conduct](http://typelevel.org/conduct.html).
+[Typelevel](http://typelevel.org/), and as such endorses the
+[Scala Code of Conduct](https://typelevel.org/code-of-conduct.html).
 
 It is one of the very first projects to have used `Lazy` from shapeless 2.1,
 which made type class derivation with implicits much more robust.

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,8 +9,8 @@ Automatic [argonaut](https://github.com/argonaut-io/argonaut) codec derivation w
 It is available for scala 2.10, 2.11, and 2.12, and depends on argonaut 6.2.
 
 argonaut-shapeless is part of the shapeless ecosystem of
-[Typelevel](http://typelevel.org/), and as such endorses its
-[Code of Conduct](http://typelevel.org/conduct.html).
+[Typelevel](http://typelevel.org/), and as such endorses the
+[Scala Code of Conduct](https://www.scala-lang.org/conduct/).
 
 It is one of the very first projects to have used `Lazy` from shapeless 2.1,
 which made type class derivation with implicits much more robust.


### PR DESCRIPTION
Typelevel is about to announce that it is moving to the Scala Code of Conduct for all participating projects. The Scala Code of Conduct was by developed by the Scala Center with input from Typelevel and improves on the Typelevel code of conduct in a number of ways and can be thought of as the "Typelevel code of conduct v. 2.0". We want people participating in projects and activities right across the Scala ecosystem to be able to expect a uniform standard of good behavior, and coordinating on a shared code of conduct is an important step in that direction.